### PR TITLE
README.md: Update command line examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Options:
 ## Docker usage
 Build the image, or pull it:
 ```sh
-docker build --build-arg BUILDER_NAME='Your Name' -build-arg BUILDER_EMAIL=your.name@example.com . -t checker
+docker build --build-arg BUILDER_NAME='Your Name' --build-arg BUILDER_EMAIL=your.name@example.com . -t checker
 ```
 
 Then run it with your Makefile attached, below is an example of it assuming the Makefile is in your current working directory:


### PR DESCRIPTION
- Use `--build-arg` for docker build (`-e` doesn't work with contemporary Docker versions)
- Use `$PWD` instead of calling `pwd`
- Quote paths to handle whitespaces
- Single quotes for static string
