### PR TITLE
Make Makefile argument optional for easier use from tools.

### DIFF
--- a/cmd/checkmake/main.go
+++ b/cmd/checkmake/main.go
@@ -20,7 +20,7 @@ var (
 	usage = `checkmake.
 
   Usage:
-  checkmake [options] <makefile>...
+  checkmake [options] [<makefile>...]
   checkmake -h | --help
   checkmake --version
   checkmake --list-rules


### PR DESCRIPTION
This seems to solve problems with running checkmake from pre-commit. It very simply makes the Makefile argument optional which means that checkmake doesn't seem to run.
(see also https://github.com/mrtazz/checkmake/issues/80 and some comments on other (closed) issues (e.g. https://github.com/mrtazz/checkmake/pull/69) 

## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [x ] CI passes
- [x ] Description of proposed change
- [x ] Documentation (README, docs/, man pages) is updated
- [x ] Existing issue is referenced if there is one
- [!! ] Unit tests for the proposed change

no unit test yet since this basically does nothing. Might investigate learning how to do that if considered worthwhile. 