### PR TITLE
build: redeclare module path to the new org

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,8 @@ exclude: |
         vendor/.*
     )$
 repos:
--   repo: https://github.com/mrtazz/checkmake.git
-    rev: main
+-   repo: https://github.com/checkmake/checkmake.git
+    rev: 0.2.2
     hooks:
     - id: checkmake
       exclude: |

--- a/README.md
+++ b/README.md
@@ -147,14 +147,14 @@ The [pandoc](https://pandoc.org/) document converter utility is required to run 
 With `go` 1.16 or higher:
 
 ```sh
-go install github.com/mrtazz/checkmake/cmd/checkmake@latest
+go install github.com/checkmake/checkmake/cmd/checkmake@latest
 checkmake Makefile
 ```
 
 Or alternatively, run it directly:
 
 ```sh
-go run github.com/mrtazz/checkmake/cmd/checkmake@latest Makefile
+go run github.com/checkmake/checkmake/cmd/checkmake@latest Makefile
 ```
 
 ### Packages
@@ -164,7 +164,7 @@ There are packages for linux up [on packagecloud.io](https://packagecloud.io/mrt
 To build checkmake you will need to have [golang](https://golang.org/) installed. Once you have Go installed, you can simply clone the repo and build the binary and man page yourself with the following commands.
 
 ```sh
-git clone https://github.com/mrtazz/checkmake
+git clone https://github.com/checkmake/checkmake
 cd checkmake
 make
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mrtazz/checkmake
+module github.com/checkmake/checkmake
 
 go 1.17
 
@@ -11,6 +11,9 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 // indirect
+	github.com/jtolds/gls v4.20.0+incompatible // indirect
+	github.com/mrtazz/checkmake v0.0.0-20250808110825-1fb2a994445b // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/smartystreets/goconvey v1.7.2 // indirect
+	github.com/smartystreets/assertions v1.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGa
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/mrtazz/checkmake v0.0.0-20250808110825-1fb2a994445b h1:vqHsrEOW2IBC+T3UUY/9dniyLTZk3QI3/glfuV9PBTk=
+github.com/mrtazz/checkmake v0.0.0-20250808110825-1fb2a994445b/go.mod h1:QmxUHDy3sMpsO8+VgE72n+3ksnWbYWXBoDHaYfMntKo=
 github.com/olekukonko/tablewriter v0.0.0-20150822215231-b9346ac189c5 h1:ZxRrPRTX45eVRfhXfZUgH1MG173pWRdOMFsnJoTaxwU=
 github.com/olekukonko/tablewriter v0.0.0-20150822215231-b9346ac189c5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
The module path was declared as github.com/mrtazz/checkmake

After the move of the repo to the checkmake org, this adjusts the path to github.com/checkmake/checkmake so that go run and go install can work again.

Also reflect this in the README and pre-commit config.

## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [ ] CI passes
- [ ] Description of proposed change
- [ ] Documentation (README, docs/, man pages) is updated
- [ ] Existing issue is referenced if there is one
- [ ] Unit tests for the proposed change
