### PR TITLE
build: set the toolchain version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/checkmake/checkmake
 
-go 1.24
+go 1.24.0
+
+toolchain go1.24.2
 
 require (
 	github.com/docopt/docopt-go v0.0.0-20141128170934-854c423c8108


### PR DESCRIPTION
## Description

This pins the go toolchain version to v1.24.2

It is a first  attempt to fix the ci build regression issue #140 






## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [ ] CI passes
- [ ] Description of proposed change
- [ ] Documentation (README, docs/, man pages) is updated
- [ ] Existing issue is referenced if there is one
- [ ] Unit tests for the proposed change
