### PR TITLE
Use go version 1.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.24
+        go-version: 1.25
       id: go
 
     - name: Check out code

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/checkmake/checkmake
 
 go 1.25
 
-toolchain go1.24.2
-
 require (
 	github.com/docopt/docopt-go v0.0.0-20141128170934-854c423c8108
 	github.com/go-ini/ini v1.67.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/checkmake/checkmake
 
-go 1.24.0
+go 1.25
 
 toolchain go1.24.2
 


### PR DESCRIPTION
## description

This updates the build and ci to use go version 1.25(.0) 

## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [ ] CI passes
- [ ] Description of proposed change
- [ ] Documentation (README, docs/, man pages) is updated
- [ ] Existing issue is referenced if there is one
- [ ] Unit tests for the proposed change
