### PR TITLE
add GetRulesSorted for deterministic rule listing

### DIFF
--- a/cmd/checkmake/main.go
+++ b/cmd/checkmake/main.go
@@ -131,7 +131,7 @@ func parseArgsAndGetFormatter(args map[string]interface{}) (formatters.Formatter
 
 func listRules(w io.Writer) {
 	data := [][]string{}
-	for _, rule := range rules.GetRegisteredRules() {
+	for _, rule := range rules.GetRulesSorted() {
 		data = append(data, []string{rule.Name(), rule.Description()})
 	}
 

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -2,6 +2,8 @@
 package rules
 
 import (
+	"sort"
+
 	"github.com/checkmake/checkmake/parser"
 )
 
@@ -50,4 +52,19 @@ func RegisterRule(r Rule) {
 // GetRegisteredRules returns the internal ruleRegistry
 func GetRegisteredRules() RuleRegistry {
 	return ruleRegistry
+}
+
+// GetRulesSorted returns all registered rules in alphabetical order by name.
+func GetRulesSorted() []Rule {
+	keys := make([]string, 0, len(ruleRegistry))
+	for name := range ruleRegistry {
+		keys = append(keys, name)
+	}
+	sort.Strings(keys)
+
+	sorted := make([]Rule, 0, len(keys))
+	for _, name := range keys {
+		sorted = append(sorted, ruleRegistry[name])
+	}
+	return sorted
 }


### PR DESCRIPTION
Add helper to return registered rules sorted by name and use it in listRules to make `checkmake --list-rules` output consistent across runs.

Fixes #162

## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [ ] CI passes
- [x] Description of proposed change
- [ ] Documentation (README, docs/, man pages) is updated
- [x] Existing issue is referenced if there is one
- [ ] Unit tests for the proposed change
