### PR TITLE
log active configuration file in debug mode

### DIFF
--- a/cmd/checkmake/main.go
+++ b/cmd/checkmake/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"log"
@@ -86,6 +87,16 @@ func runCheckmake(makefiles []string) error {
 	cfg, cfgError := config.NewConfigFromFile(cfgPath)
 	if cfgError != nil {
 		logger.Info(fmt.Sprintf("Unable to parse config file %q, running with defaults", cfgPath))
+	} else {
+		logger.Debug(fmt.Sprintf("Using configuration file: %q", cfgPath))
+		if debug {
+			if iniFile := cfg.Ini(); iniFile != nil {
+				var buf bytes.Buffer
+				if _, err := iniFile.WriteTo(&buf); err == nil {
+					logger.Debug(fmt.Sprintf("Parsed configuration:\n%s", buf.String()))
+				}
+			}
+		}
 	}
 
 	logger.Debug(fmt.Sprintf("Makefiles passed: %q", makefiles))

--- a/config/config.go
+++ b/config/config.go
@@ -74,3 +74,8 @@ func (c *Config) GetConfigValue(keyName string) (value string, err error) {
 
 	return "", fmt.Errorf("config has no default section")
 }
+
+// Ini returns the underlying ini.File instance for debugging or advanced inspection.
+func (c *Config) Ini() *ini.File {
+	return c.iniFile
+}


### PR DESCRIPTION
Adds a `Config.Ini()` accessor for debugging, and logs the active configuration file (and parsed contents) when `--debug` is enabled. Helps confirm which file and values are in use at runtime.