### PR TITLE
fix(logging): restore debug log for listed makefiles

### DIFF
--- a/cmd/checkmake/main.go
+++ b/cmd/checkmake/main.go
@@ -88,6 +88,8 @@ func runCheckmake(makefiles []string) error {
 		logger.Info(fmt.Sprintf("Unable to parse config file %q, running with defaults", cfgPath))
 	}
 
+	logger.Debug(fmt.Sprintf("Makefiles passed: %q", makefiles))
+
 	var violations rules.RuleViolationList
 	for _, mkf := range makefiles {
 		logger.Info(fmt.Sprintf("Parsing file %q", mkf))


### PR DESCRIPTION
Reintroduce the "Makefiles passed" debug message that was lost after the Cobra migration. Adds a targeted test to verify debug output is emitted when using the `--debug` flag, matching previous behavior.

## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [x] Teset passes
- [x] Description of proposed change
- [x] Documentation (README, docs/, man pages) is updated
- [ ] Existing issue is referenced if there is one
- [x] Unit tests for the proposed change
