### PR TITLE
fix(cli): show help when no arguments are provided

### DIFF
--- a/cmd/checkmake/main.go
+++ b/cmd/checkmake/main.go
@@ -37,6 +37,10 @@ func newRootCmd() *cobra.Command {
 		Args:         cobra.ArbitraryArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				_ = cmd.Help()
+				return nil
+			}
 			return runCheckmake(args)
 		},
 	}

--- a/cmd/checkmake/main_test.go
+++ b/cmd/checkmake/main_test.go
@@ -34,6 +34,18 @@ func captureOutput(f func()) string {
 	return buf.String()
 }
 
+func TestCheckmake_NoArgsShowsHelp(t *testing.T) {
+	out := captureOutput(func() {
+		cmd := newRootCmd()
+		cmd.SetArgs([]string{}) // no args
+		err := cmd.Execute()
+		require.NoError(t, err, "command without args should not fail")
+	})
+
+	assert.Contains(t, out, "Usage:", "expected help output to be shown")
+	assert.Contains(t, out, "checkmake [flags]", "should display root usage line")
+}
+
 func TestCheckmake_RunWithSimpleMakefile(t *testing.T) {
 	t.Parallel()
 	cmd := newRootCmd()


### PR DESCRIPTION
Restore the expected behavior where running `checkmake` without arguments prints the usage help, matching common CLI conventions and previous behavior.

Previous behavior:

```
$ checkmake 
Usage:
  checkmake [options] <makefile>...
  checkmake -h | --help
  checkmake --version
  checkmake --list-rule
```

After Cobra migration:

```
./checkmake
```

With this patch:

```
./checkmake 
checkmake scans Makefiles and reports potential issues according to configurable rules.

Usage:
  checkmake [flags] [makefile...]
  checkmake [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  list-rules  List registered rules

Flags:
      --config string   Configuration file to read (default "checkmake.ini")
      --debug           Enable debug mode
      --format string   Output format as a Go text/template template
  -h, --help            help for checkmake
  -v, --version         version for checkmake

Use "checkmake [command] --help" for more information about a command.

```
