### PR TITLE
feat(cli): Make `list-rules` command config-aware

### DIFF
--- a/cmd/checkmake/main_test.go
+++ b/cmd/checkmake/main_test.go
@@ -149,3 +149,21 @@ func TestCheckmake_DebugLogsMakefilesPassed(t *testing.T) {
 	assert.Contains(t, logs, "simple.make")
 	assert.Contains(t, logs, "missing_phony.make")
 }
+
+func TestCheckmake_ListRules_UsesConfig(t *testing.T) {
+	cmd := newRootCmd()
+	cmd.SetArgs([]string{"--config", "../../fixtures/custom_rules.ini", "list-rules"})
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+
+	err := cmd.Execute()
+	require.NoError(t, err, "list-rules should run successfully with config")
+
+	output := buf.String()
+	t.Logf("list-rules output:\n%s", output)
+
+	assert.Regexp(t, `3\s+lines`, output, "custom maxBodyLength from config should appear in output")
+	assert.Regexp(t, `foo,\s*bar`, output, "custom required phonies from config should appear in output")
+}

--- a/fixtures/custom_rules.ini
+++ b/fixtures/custom_rules.ini
@@ -1,0 +1,4 @@
+[maxbodylength]
+maxBodyLength = 3
+[minphony]
+required = foo, bar

--- a/rules/maxbodylength/maxbodylength.go
+++ b/rules/maxbodylength/maxbodylength.go
@@ -32,7 +32,14 @@ func (m *MaxBodyLength) Name() string {
 }
 
 // Description returns the description of the rule
-func (m *MaxBodyLength) Description() string {
+func (m *MaxBodyLength) Description(cfg rules.RuleConfig) string {
+	if cfg != nil {
+		if confLength, ok := cfg["maxBodyLength"]; ok {
+			if i, err := strconv.Atoi(confLength); err == nil {
+				return fmt.Sprintf("Target bodies should be kept simple and short (no more than %d lines).", i)
+			}
+		}
+	}
 	return fmt.Sprintf("Target bodies should be kept simple and short (no more than %d lines).", maxBodyLength)
 }
 

--- a/rules/maxbodylength/maxbodylength_test.go
+++ b/rules/maxbodylength/maxbodylength_test.go
@@ -30,7 +30,7 @@ func TestFooIsTooLong(t *testing.T) {
 
 	assert.Equal(t, 1, len(ret))
 	assert.Equal(t, "Target bodies should be kept simple and short (no more than 5 lines).",
-		rule.Description())
+		rule.Description(nil))
 	assert.Equal(t, "Target body for \"foo\" exceeds allowed length of 5 lines (7).", ret[0].Violation)
 	assert.Equal(t, 1, ret[0].LineNumber)
 	assert.Equal(t, "maxbodylength.mk", ret[0].FileName)
@@ -58,7 +58,7 @@ func TestFooIsTooLongWithConfig(t *testing.T) {
 
 	assert.Equal(t, 1, len(ret))
 	assert.Equal(t, "Target bodies should be kept simple and short (no more than 3 lines).",
-		rule.Description())
+		rule.Description(nil))
 	assert.Equal(t, "Target body for \"foo\" exceeds allowed length of 3 lines (4).", ret[0].Violation)
 	assert.Equal(t, 1, ret[0].LineNumber)
 	assert.Equal(t, "maxbodylength.mk", ret[0].FileName)

--- a/rules/minphony/minphony.go
+++ b/rules/minphony/minphony.go
@@ -33,8 +33,13 @@ func (r *MinPhony) Name() string {
 }
 
 // Description returns the description of the rule
-func (r *MinPhony) Description() string {
-	return fmt.Sprintf("Minimum required phony targets must be present (%s)", strings.Join(r.required, ","))
+func (r *MinPhony) Description(cfg rules.RuleConfig) string {
+	if cfg != nil {
+		if req, ok := cfg["required"]; ok && req != "" {
+			return fmt.Sprintf("Minimum required phony targets must be present (%s).", req)
+		}
+	}
+	return fmt.Sprintf("Minimum required phony targets must be present (%s).", strings.Join(r.required, ","))
 }
 
 // Run executes the rule logic

--- a/rules/minphony/minphony_test.go
+++ b/rules/minphony/minphony_test.go
@@ -74,9 +74,9 @@ func TestMinPhony_new(t *testing.T) {
 
 	assert.Equal(t, []string{"oh", "hai"}, mp.required)
 	assert.Equal(t, "minphony", mp.Name())
-	expected_desc := fmt.Sprintf("Minimum required phony targets must be present (%s)", strings.Join(mp.required, ","))
+	expected_desc := fmt.Sprintf("Minimum required phony targets must be present (%s).", strings.Join(mp.required, ","))
 
-	assert.Equal(t, expected_desc, mp.Description())
+	assert.Equal(t, expected_desc, mp.Description(nil))
 }
 
 func TestMinPhony_Run(t *testing.T) {

--- a/rules/phonydeclared/phonydeclared.go
+++ b/rules/phonydeclared/phonydeclared.go
@@ -24,7 +24,7 @@ func (r *Phonydeclared) Name() string {
 }
 
 // Description returns the description of the rule
-func (r *Phonydeclared) Description() string {
+func (r *Phonydeclared) Description(cfg rules.RuleConfig) string {
 	return "Every target without a body needs to be marked PHONY"
 }
 

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -7,10 +7,18 @@ import (
 	"github.com/checkmake/checkmake/parser"
 )
 
-// Rule is the type of a rule function
+// Rule defines the interface that all validation rules must implement.
+//
+// Each rule provides:
+//   - Name(): a unique identifier string for the rule.
+//   - Description(cfg RuleConfig): a human-readable explanation of what the rule checks for.
+//     Implementations should adapt the description based on the provided configuration,
+//     but must remain safe to call with a nil config (using default values).
+//   - Run(makefile, cfg): performs the actual validation on the parsed Makefile,
+//     returning a list of any violations found.
 type Rule interface {
 	Name() string
-	Description() string
+	Description(cfg RuleConfig) string
 	Run(parser.Makefile, RuleConfig) RuleViolationList
 }
 

--- a/rules/timestampexpanded/timestampexpanded.go
+++ b/rules/timestampexpanded/timestampexpanded.go
@@ -32,7 +32,7 @@ func (r *Timestampexpanded) Name() string {
 }
 
 // Description returns the description of the rule
-func (r *Timestampexpanded) Description() string {
+func (r *Timestampexpanded) Description(cfg rules.RuleConfig) string {
 	return "timestamp variables should be simply expanded"
 }
 

--- a/rules/timestampexpanded/timestampexpanded_test.go
+++ b/rules/timestampexpanded/timestampexpanded_test.go
@@ -24,7 +24,7 @@ func TestVersionIsNotSimplyExpanded(t *testing.T) {
 
 	assert.Equal(t, 1, len(ret))
 	assert.Equal(t, "timestamp variables should be simply expanded",
-		rule.Description())
+		rule.Description(nil))
 	for i := range ret {
 		assert.Equal(t, "timestamp-expanded.mk", ret[i].FileName)
 	}


### PR DESCRIPTION
Refactor the `Rule` interface so `Description` accepts a `RuleConfig` argument, allowing each rule to generate context-specific descriptions based on configuration values.

Fixes #115 