### PR TITLE
parser: skip debug log for empty lines

### DIFF
--- a/fixtures/unknown_lines.make
+++ b/fixtures/unknown_lines.make
@@ -1,0 +1,18 @@
+# This file tests how the parser handles empty and unknown lines
+# Empty line follows
+
+thisisnotarule
+
+all:
+	@echo all
+.PHONY: all
+
+clean:
+	@echo clean
+.PHONY: clean
+
+test:
+	@echo test
+.PHONY: test
+
+

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -172,7 +172,9 @@ func parseRuleOrVariable(scanner *MakefileScanner) (ret interface{}, err error) 
 			LineNumber:     scanner.LineNumber}
 		scanner.Scan()
 	} else {
-		logger.Debug(fmt.Sprintf("Unable to match line '%s' to a Rule or Variable", line))
+		if strings.TrimSpace(line) != "" {
+			logger.Debug(fmt.Sprintf("Unable to match line '%s' to a Rule or Variable", line))
+		}
 		scanner.Scan()
 	}
 


### PR DESCRIPTION
Avoid noisy debug messages for empty lines that report:

 "Unable to match line '' to a Rule or Variable"

Fixes #84