### PR TITLE
rules: add uniquetargets rule to detect repeated Makefile targets

### DIFF
--- a/rules/uniquetargets/uniquetargets.go
+++ b/rules/uniquetargets/uniquetargets.go
@@ -1,0 +1,71 @@
+// Package uniquetargets implements the ruleset ensuring no target is repeated.
+package uniquetargets
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/checkmake/checkmake/parser"
+	"github.com/checkmake/checkmake/rules"
+)
+
+func init() {
+	rules.RegisterRule(&UniqueTargets{})
+}
+
+// UniqueTargets ensures targets are not defined multiple times.
+type UniqueTargets struct{}
+
+// Name returns the rule's identifier.
+func (r *UniqueTargets) Name() string {
+	return "uniquetargets"
+}
+
+// Description returns the human-readable description.
+func (r *UniqueTargets) Description(cfg rules.RuleConfig) string {
+	if cfg != nil {
+		if ignored, ok := cfg["ignore"]; ok && ignored != "" {
+			return fmt.Sprintf("Targets should be uniquely defined (ignoring: %s).", ignored)
+		}
+	}
+	return "Targets should be uniquely defined; duplicates can cause recipe overrides or unintended merges."
+}
+
+// Run detects non-unique target definitions, optionally skipping ignored ones.
+func (r *UniqueTargets) Run(makefile parser.Makefile, cfg rules.RuleConfig) rules.RuleViolationList {
+	seen := make(map[string]int)
+	violations := rules.RuleViolationList{}
+
+	// Load optional ignore list
+	ignoredTargets := map[string]bool{}
+	if cfg != nil {
+		if ignoreList, ok := cfg["ignore"]; ok {
+			for _, target := range strings.Split(ignoreList, ",") {
+				target = strings.TrimSpace(target)
+				if target != "" {
+					ignoredTargets[target] = true
+				}
+			}
+		}
+	}
+
+	for _, rule := range makefile.Rules {
+		// Skip ignored targets
+		if ignoredTargets[rule.Target] {
+			continue
+		}
+
+		if prevLine, exists := seen[rule.Target]; exists {
+			violations = append(violations, rules.RuleViolation{
+				Rule:       r.Name(),
+				Violation:  fmt.Sprintf(`Target "%s" defined multiple times (lines %d and %d).`, rule.Target, prevLine, rule.LineNumber),
+				FileName:   makefile.FileName,
+				LineNumber: rule.LineNumber,
+			})
+		} else {
+			seen[rule.Target] = rule.LineNumber
+		}
+	}
+
+	return violations
+}

--- a/rules/uniquetargets/uniquetargets_test.go
+++ b/rules/uniquetargets/uniquetargets_test.go
@@ -1,0 +1,66 @@
+package uniquetargets
+
+import (
+	"testing"
+
+	"github.com/checkmake/checkmake/parser"
+	"github.com/checkmake/checkmake/rules"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUniqueTargets(t *testing.T) {
+	makefile := parser.Makefile{
+		FileName: "no-duplicates.mk",
+		Rules: []parser.Rule{
+			{Target: "all", LineNumber: 1},
+			{Target: "test", LineNumber: 5},
+			{Target: "clean", LineNumber: 9},
+		},
+	}
+
+	rule := UniqueTargets{}
+	ret := rule.Run(makefile, rules.RuleConfig{})
+
+	assert.Equal(t, 0, len(ret), "no duplicates should produce no violations")
+}
+
+func TestNoUniqueTargetsDetected(t *testing.T) {
+	makefile := parser.Makefile{
+		FileName: "unique_targets.mk",
+		Rules: []parser.Rule{
+			{Target: "test", LineNumber: 2},
+			{Target: "build", LineNumber: 5},
+			{Target: "test", LineNumber: 8}, // duplicate
+		},
+	}
+
+	rule := UniqueTargets{}
+	ret := rule.Run(makefile, rules.RuleConfig{})
+
+	assert.Equal(t, 1, len(ret), "expected one duplicate violation")
+	assert.Contains(t, ret[0].Violation, `"test" defined multiple times`)
+	assert.Equal(t, "unique_targets.mk", ret[0].FileName)
+	assert.Equal(t, 8, ret[0].LineNumber)
+}
+
+func TestUniqueTargetsIgnoredByConfig(t *testing.T) {
+	makefile := parser.Makefile{
+		FileName: "unique_ignored.mk",
+		Rules: []parser.Rule{
+			{Target: "all", LineNumber: 1},
+			{Target: "test", LineNumber: 3},
+			{Target: "test", LineNumber: 6}, // duplicate but ignored
+			{Target: "deploy", LineNumber: 9},
+			{Target: "deploy", LineNumber: 12}, // not ignored
+		},
+	}
+
+	rule := UniqueTargets{}
+	cfg := rules.RuleConfig{"ignore": "test,clean"}
+
+	ret := rule.Run(makefile, cfg)
+
+	assert.Equal(t, 1, len(ret), "only non-ignored duplicates should trigger violations")
+	assert.Contains(t, ret[0].Violation, `"deploy" defined multiple times`)
+	assert.NotContains(t, ret[0].Violation, `"test"`)
+}

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -16,11 +16,11 @@ import (
 	_ "github.com/checkmake/checkmake/rules/minphony"
 	_ "github.com/checkmake/checkmake/rules/phonydeclared"
 	_ "github.com/checkmake/checkmake/rules/timestampexpanded"
+	_ "github.com/checkmake/checkmake/rules/uniquetargets"
 )
 
 // Validate let's you validate a passed in Makefile with the provided config
 func Validate(makefile parser.Makefile, cfg *config.Config) (ret rules.RuleViolationList) {
-
 	rules := rules.GetRegisteredRules()
 
 	for name, rule := range rules {


### PR DESCRIPTION
This new rule warns when the same target is defined multiple times, which can cause recipe overrides in GNU Make or unintended merges in BSD Make. The rule supports an optional `ignore` configuration key to skip specific targets.
