### PR TITLE
ensure required PHONY targets also exist as real targets

### DIFF
--- a/fixtures/all_targets_present.make
+++ b/fixtures/all_targets_present.make
@@ -1,0 +1,9 @@
+.PHONY: all clean test
+
+all:
+	@echo all
+clean:
+	@echo clean
+test:
+	@echo test
+

--- a/fixtures/missing_targets.make
+++ b/fixtures/missing_targets.make
@@ -1,0 +1,2 @@
+# .PHONY declares targets that are not actually defined in the file
+.PHONY: all clean test

--- a/formatters/custom_test.go
+++ b/formatters/custom_test.go
@@ -22,8 +22,8 @@ func TestCustomFormatter(t *testing.T) {
 
 	violations := validator.Validate(makefile, &config.Config{})
 	formatter.Format(violations)
-	assert.Regexp(t, `../fixtures/missing_phony.make:21:minphony:Missing required phony target "all"`, out.String())
-	assert.Regexp(t, `../fixtures/missing_phony.make:21:minphony:Missing required phony target "test"`, out.String())
+	assert.Regexp(t, `../fixtures/missing_phony.make:21:minphony:Required target "all" must be declared PHONY.`, out.String())
+	assert.Regexp(t, `../fixtures/missing_phony.make:21:minphony:Required target "test" must be declared PHONY.`, out.String())
 	assert.Regexp(t, `../fixtures/missing_phony.make:16:phonydeclared:Target "all" should be declared PHONY.`, out.String())
 	assert.Equal(t, strings.Count(out.String(), "\n"), 3)
 }

--- a/rules/minphony/minphony_test.go
+++ b/rules/minphony/minphony_test.go
@@ -28,19 +28,19 @@ var mpRunTests = []struct {
 		vl: rules.RuleViolationList{
 			rules.RuleViolation{
 				Rule:       "minphony",
-				Violation:  "Missing required phony target \"kleen\"",
+				Violation:  "Required target \"kleen\" is missing from the Makefile.",
 				FileName:   "green-eggs.mk",
 				LineNumber: -1,
 			},
 			rules.RuleViolation{
 				Rule:       "minphony",
-				Violation:  "Missing required phony target \"awl\"",
+				Violation:  "Required target \"awl\" is missing from the Makefile.",
 				FileName:   "green-eggs.mk",
 				LineNumber: -1,
 			},
 			rules.RuleViolation{
 				Rule:       "minphony",
-				Violation:  "Missing required phony target \"toast\"",
+				Violation:  "Required target \"toast\" is missing from the Makefile.",
 				FileName:   "green-eggs.mk",
 				LineNumber: -1,
 			},
@@ -61,7 +61,7 @@ var mpRunTests = []struct {
 		vl: rules.RuleViolationList{
 			rules.RuleViolation{
 				Rule:       "minphony",
-				Violation:  "Missing required phony target \"toast\"",
+				Violation:  "Required target \"toast\" is missing from the Makefile.",
 				FileName:   "kleen.mk",
 				LineNumber: -1,
 			},
@@ -102,13 +102,13 @@ func TestMinPhony_RunWithConfig(t *testing.T) {
 	vl := rules.RuleViolationList{
 		rules.RuleViolation{
 			Rule:       "minphony",
-			Violation:  "Missing required phony target \"foo\"",
+			Violation:  "Required target \"foo\" is missing from the Makefile.",
 			FileName:   "test.mk",
 			LineNumber: -1,
 		},
 		rules.RuleViolation{
 			Rule:       "minphony",
-			Violation:  "Missing required phony target \"bar\"",
+			Violation:  "Required target \"bar\" is missing from the Makefile.",
 			FileName:   "test.mk",
 			LineNumber: -1,
 		},
@@ -122,4 +122,25 @@ func TestMinPhony_RunWithConfig(t *testing.T) {
 	vl = rules.RuleViolationList{}
 
 	assert.Equal(t, vl, mp.Run(mf, cfg))
+}
+
+func TestMinPhony_MissingPhonyDeclaration(t *testing.T) {
+	makefile := parser.Makefile{
+		FileName: "missing-phony.mk",
+		Rules: []parser.Rule{
+			{Target: "all"},
+			{Target: "clean"},
+			{Target: "test"},
+		},
+		Variables: []parser.Variable{
+			{Name: "PHONY", Assignment: "all"}, // only "all" declared
+		},
+	}
+
+	mp := &MinPhony{required: []string{"all", "clean", "test"}}
+	ret := mp.Run(makefile, rules.RuleConfig{})
+
+	assert.Len(t, ret, 2, "expected two missing PHONY declaration violations")
+	assert.Equal(t, "Required target \"clean\" must be declared PHONY.", ret[0].Violation)
+	assert.Equal(t, "Required target \"test\" must be declared PHONY.", ret[1].Violation)
 }


### PR DESCRIPTION
The minphony rule now validates that required targets are both:
  - declared as PHONY, and
  - actually defined in the Makefile.

Fixes: #172
Fixes: #87 