### PR TITLE
cmd: avoid warning when configuration is not available

### DIFF
--- a/cmd/checkmake/main.go
+++ b/cmd/checkmake/main.go
@@ -82,7 +82,7 @@ func loadConfig() *config.Config {
 
 	cfg, cfgError := config.NewConfigFromFile(cfgPath)
 	if cfgError != nil {
-		logger.Error(fmt.Sprintf("Unable to parse config file %q, running with defaults", cfgPath))
+		logger.Info(fmt.Sprintf("Unable to parse config file %q, running with defaults", cfgPath))
 		return &config.Config{}
 	}
 


### PR DESCRIPTION
Lower log level from Error to Info when no config file is found, restoring previous behavior where checkmake produced no stderr output for missing configuration.

Fix #176