### PR TITLE
Makefile: remove unused vendor target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,8 +139,6 @@ deploy-packages: packages
 	package_cloud push mrtazz/$(NAME)/debian/trixie *.deb
 	package_cloud push mrtazz/$(NAME)/ubuntu/hirsute *.deb
 
-vendor:
-	go mod vendor
 
 rpm: $(SOURCES)
 	  fpm -t rpm -s dir \
@@ -195,4 +193,4 @@ pizza: # ignore checkmake
 	@echo ""
 	@echo ""
 
-.PHONY: all test rpm deb install local-install packages vendor coverage clean-deps clean clean-docs pizza binaries
+.PHONY: all test rpm deb install local-install packages coverage clean-deps clean clean-docs pizza binaries


### PR DESCRIPTION
vendoring was removed from the repository
a short while ago.

Therefore, the vendor make target is no longer needed.

This removes it.

## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [ ] CI passes
- [x] Description of proposed change
- [ ] Documentation (README, docs/, man pages) is updated
- [x] Existing issue is referenced if there is one
- [ ] Unit tests for the proposed change
