### PR TITLE
feat(parser): improve rule detection, inline recipe parsing, and PHONY handling

### DIFF
--- a/cmd/checkmake/main_test.go
+++ b/cmd/checkmake/main_test.go
@@ -120,7 +120,7 @@ func TestCheckmake_WithCustomFormatFlag(t *testing.T) {
 
 	// There are three expected rules in missing_phony.make: phonydeclared and minphony twice
 	assert.Contains(t, out, "phonydeclared on 16")
-	assert.Contains(t, out, "minphony on 21")
+	assert.Contains(t, out, "minphony on 22")
 }
 
 func TestCheckmake_DebugLogsMakefilesPassed(t *testing.T) {

--- a/formatters/custom_test.go
+++ b/formatters/custom_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestCustomFormatter(t *testing.T) {
+	t.Parallel()
 	out := new(bytes.Buffer)
 
 	tmpl, _ := template.New("test").Parse("{{.FileName}}:{{.LineNumber}}:{{.Rule}}:{{.Violation}}")
@@ -22,19 +23,21 @@ func TestCustomFormatter(t *testing.T) {
 
 	violations := validator.Validate(makefile, &config.Config{})
 	formatter.Format(violations)
-	assert.Regexp(t, `../fixtures/missing_phony.make:21:minphony:Required target "all" must be declared PHONY.`, out.String())
-	assert.Regexp(t, `../fixtures/missing_phony.make:21:minphony:Required target "test" must be declared PHONY.`, out.String())
+	assert.Regexp(t, `../fixtures/missing_phony.make:22:minphony:Required target "all" must be declared PHONY.`, out.String())
+	assert.Regexp(t, `../fixtures/missing_phony.make:22:minphony:Required target "test" must be declared PHONY.`, out.String())
 	assert.Regexp(t, `../fixtures/missing_phony.make:16:phonydeclared:Target "all" should be declared PHONY.`, out.String())
 	assert.Equal(t, strings.Count(out.String(), "\n"), 3)
 }
 
 func TestCustomFormatterNewMethod(t *testing.T) {
+	t.Parallel()
 	_, err := NewCustomFormatter("{{.FileName}}:{{.LineNumber}}:{{.Rule}}:{{.Violation}}")
 
 	assert.Equal(t, nil, err)
 }
 
 func TestCustomFormatterNewMethodFailing(t *testing.T) {
+	t.Parallel()
 	_, err := NewCustomFormatter("{{.LineNumber}}:{{.Rule}}:{{.Violation}}{{end}}")
 
 	assert.NotEqual(t, nil, err)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -12,12 +12,13 @@ import (
 )
 
 func TestParseSimpleMakefile(t *testing.T) {
+	t.Parallel()
 	ret, err := Parse("../fixtures/simple.make")
 
 	assert.Equal(t, err, nil)
 	assert.Equal(t, ret.FileName, "../fixtures/simple.make")
-	assert.Equal(t, len(ret.Rules), 5)
-	assert.Equal(t, len(ret.Variables), 4)
+	assert.Equal(t, len(ret.Rules), 7)
+	assert.Equal(t, len(ret.Variables), 2)
 	assert.Equal(t, ret.Rules[0].Target, "clean")
 	assert.Equal(t, ret.Rules[0].Body, []string{"rm bar", "rm foo"})
 	assert.Equal(t, ret.Rules[0].FileName, "../fixtures/simple.make")
@@ -35,6 +36,14 @@ func TestParseSimpleMakefile(t *testing.T) {
 	assert.Equal(t, ret.Rules[3].Dependencies, []string{"foo"})
 	assert.Equal(t, ret.Rules[3].FileName, "../fixtures/simple.make")
 
+	assert.Equal(t, ".PHONY", ret.Rules[5].Target)
+	assert.Equal(t, []string{"all", "clean", "test"}, ret.Rules[5].Dependencies)
+	assert.Equal(t, "../fixtures/simple.make", ret.Rules[5].FileName)
+
+	assert.Equal(t, ".DEFAULT_GOAL", ret.Rules[6].Target)
+	assert.Equal(t, []string{"all"}, ret.Rules[6].Dependencies)
+	assert.Equal(t, "../fixtures/simple.make", ret.Rules[6].FileName)
+
 	assert.Equal(t, ret.Variables[0].Name, "expanded")
 	assert.Equal(t, ret.Variables[0].Assignment, "\"$(simple)\"")
 	assert.Equal(t, ret.Variables[0].SimplyExpanded, false)
@@ -46,21 +55,10 @@ func TestParseSimpleMakefile(t *testing.T) {
 	assert.Equal(t, ret.Variables[1].SimplyExpanded, true)
 	assert.Equal(t, ret.Variables[1].SpecialVariable, false)
 	assert.Equal(t, ret.Variables[1].FileName, "../fixtures/simple.make")
-
-	assert.Equal(t, ret.Variables[2].Name, "PHONY")
-	assert.Equal(t, ret.Variables[2].Assignment, "all clean test")
-	assert.Equal(t, ret.Variables[2].SimplyExpanded, false)
-	assert.Equal(t, ret.Variables[2].SpecialVariable, true)
-	assert.Equal(t, ret.Variables[2].FileName, "../fixtures/simple.make")
-
-	assert.Equal(t, ret.Variables[3].Name, "DEFAULT_GOAL")
-	assert.Equal(t, ret.Variables[3].Assignment, "all")
-	assert.Equal(t, ret.Variables[3].SimplyExpanded, false)
-	assert.Equal(t, ret.Variables[3].SpecialVariable, true)
-	assert.Equal(t, ret.Variables[3].FileName, "../fixtures/simple.make")
 }
 
 func TestParse_IgnoresEmptyLinesInDebug(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	logger.SetLogLevel(logger.DebugLevel)
 	log.SetOutput(&buf)
@@ -76,4 +74,263 @@ func TestParse_IgnoresEmptyLinesInDebug(t *testing.T) {
 
 	assert.NotContains(t, output, "Unable to match line ''",
 		"empty lines should not trigger debug messages")
+}
+
+func writeTempMakefile(t *testing.T, content string) string {
+	f, err := os.CreateTemp("", "*.mk")
+	require.NoError(t, err)
+	_, err = f.WriteString(content)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	return f.Name()
+}
+
+func TestParse_VariableVsRuleMisclassification(t *testing.T) {
+	t.Parallel()
+	makefile := `
+ifeq ($(OS), Windows_NT)
+MKDIR := $(shell which mkdir.exe)
+else
+MKDIR := mkdir
+endif
+`
+	tmp := writeTempMakefile(t, makefile)
+	defer os.Remove(tmp)
+
+	ret, err := Parse(tmp)
+	require.NoError(t, err)
+
+	varNames := []string{}
+	for _, v := range ret.Variables {
+		varNames = append(varNames, v.Name)
+	}
+
+	assert.Contains(t, varNames, "MKDIR", "MKDIR should be parsed as a variable, not a rule")
+	assert.Empty(t, ret.Rules, "no rules should be parsed in this makefile")
+}
+
+func TestParse_BuildRuleRecognized(t *testing.T) {
+	t.Parallel()
+	makefile := `
+build: clean ${BUILD_DIR}
+	@echo building...
+`
+	tmp := writeTempMakefile(t, makefile)
+	defer os.Remove(tmp)
+
+	ret, err := Parse(tmp)
+	require.NoError(t, err)
+
+	assert.Len(t, ret.Rules, 1)
+	assert.Equal(t, "build", ret.Rules[0].Target)
+	assert.Contains(t, ret.Rules[0].Dependencies, "${BUILD_DIR}")
+	assert.Equal(t, "@echo building...", ret.Rules[0].Body[0])
+}
+
+func TestParse_PatternAndPhonyRules(t *testing.T) {
+	t.Parallel()
+	makefile := `
+%.o: %.c
+	@echo compiling
+.PHONY: all clean
+`
+	tmp := writeTempMakefile(t, makefile)
+	defer os.Remove(tmp)
+
+	ret, err := Parse(tmp)
+	require.NoError(t, err)
+
+	targets := []string{}
+	for _, r := range ret.Rules {
+		targets = append(targets, r.Target)
+	}
+
+	assert.Contains(t, targets, "%.o")
+	assert.Contains(t, targets, ".PHONY")
+}
+
+func TestParse_TargetsWithSpecialChars(t *testing.T) {
+	t.Parallel()
+	makefile := `
+target_with_underscores:
+	echo "underscore"
+target-with-hyphens  :
+	echo "hyphen"
+`
+	tmp := writeTempMakefile(t, makefile)
+	defer os.Remove(tmp)
+
+	ret, err := Parse(tmp)
+	require.NoError(t, err)
+
+	targets := []string{}
+	for _, r := range ret.Rules {
+		targets = append(targets, r.Target)
+	}
+
+	assert.Contains(t, targets, "target_with_underscores")
+	assert.Contains(t, targets, "target-with-hyphens")
+}
+
+func TestParse_MultipleTargetsAndSpaces(t *testing.T) {
+	t.Parallel()
+	makefile := `
+target1 target2 : dep
+	echo "build both"
+`
+	tmp := writeTempMakefile(t, makefile)
+	defer os.Remove(tmp)
+
+	ret, err := Parse(tmp)
+	require.NoError(t, err)
+	require.Len(t, ret.Rules, 1)
+
+	assert.Equal(t, "target1 target2", ret.Rules[0].Target)
+	assert.Contains(t, ret.Rules[0].Dependencies, "dep")
+}
+
+func TestParse_InlineRecipeAfterColon(t *testing.T) {
+	t.Parallel()
+	makefile := `
+inline: dep ; echo "one-line recipe"
+no_deps:; echo "no deps"
+`
+	tmp := writeTempMakefile(t, makefile)
+	defer os.Remove(tmp)
+
+	ret, err := Parse(tmp)
+	require.NoError(t, err)
+
+	assert.Equal(t, "inline", ret.Rules[0].Target)
+	assert.Equal(t, []string{"dep"}, ret.Rules[0].Dependencies)
+	assert.Contains(t, ret.Rules[0].Body[0], "echo")
+
+	assert.Equal(t, "no_deps", ret.Rules[1].Target)
+	assert.Empty(t, ret.Rules[1].Dependencies)
+}
+
+func TestParse_MultiTargetWithDepsAndInlineRecipe(t *testing.T) {
+	t.Parallel()
+	makefile := `
+target1 target2 : dep1 dep2 ; echo "combo build"
+	@echo "more lines"
+`
+	tmp := writeTempMakefile(t, makefile)
+	defer os.Remove(tmp)
+
+	ret, err := Parse(tmp)
+	require.NoError(t, err)
+	require.Len(t, ret.Rules, 1)
+
+	rule := ret.Rules[0]
+	assert.Equal(t, "target1 target2", rule.Target)
+	assert.Equal(t, []string{"dep1", "dep2"}, rule.Dependencies)
+	assert.Contains(t, rule.Body[0], "combo build")
+	assert.Contains(t, rule.Body[1], "more lines")
+}
+
+func TestParse_FileExtAndVariableTargets(t *testing.T) {
+	t.Parallel()
+	makefile := `
+file.ext:
+	touch $@
+$(DIR_VAR):
+	echo "dir var"
+${DIR_VAR}/subdir:
+	echo "subdir rule"
+`
+	tmp := writeTempMakefile(t, makefile)
+	defer os.Remove(tmp)
+
+	ret, err := Parse(tmp)
+	require.NoError(t, err)
+
+	targets := []string{}
+	for _, r := range ret.Rules {
+		targets = append(targets, r.Target)
+	}
+
+	assert.Contains(t, targets, "file.ext")
+	assert.Contains(t, targets, "$(DIR_VAR)")
+	assert.Contains(t, targets, "${DIR_VAR}/subdir")
+}
+
+func TestParse_RuleWithEqualsInPrereq(t *testing.T) {
+	t.Parallel()
+	makefile := `
+target: prerequisite = value
+	@echo "rule with equals"
+`
+	tmp := writeTempMakefile(t, makefile)
+	defer os.Remove(tmp)
+
+	ret, err := Parse(tmp)
+	require.NoError(t, err)
+
+	require.Len(t, ret.Rules, 1)
+	assert.Equal(t, "target", ret.Rules[0].Target)
+	assert.Equal(t, []string{"prerequisite", "=", "value"}, ret.Rules[0].Dependencies)
+
+	require.Len(t, ret.Rules[0].Body, 1)
+	assert.Equal(t, "@echo \"rule with equals\"", ret.Rules[0].Body[0])
+}
+
+func TestParse_OtherVariableAssignments(t *testing.T) {
+	t.Parallel()
+	makefile := `
+CONDITIONAL ?= default-value
+SHELL_VAR != shell command
+APPEND_VAR += more stuff
+`
+	tmp := writeTempMakefile(t, makefile)
+	defer os.Remove(tmp)
+
+	ret, err := Parse(tmp)
+	require.NoError(t, err)
+
+	vars := make(map[string]Variable)
+	for _, v := range ret.Variables {
+		vars[v.Name] = v
+	}
+
+	condVar, ok := vars["CONDITIONAL"]
+	require.True(t, ok)
+	assert.Equal(t, "default-value", condVar.Assignment)
+	assert.False(t, condVar.SimplyExpanded, "?= should be recursive (false)")
+
+	shellVar, ok := vars["SHELL_VAR"]
+	require.True(t, ok)
+	assert.Equal(t, "shell command", shellVar.Assignment)
+	assert.True(t, shellVar.SimplyExpanded, "!= should be simple (true)")
+
+	appendVar, ok := vars["APPEND_VAR"]
+	require.True(t, ok)
+	assert.Equal(t, "more stuff", appendVar.Assignment)
+	assert.False(t, appendVar.SimplyExpanded, "+= should default to recursive (false)")
+}
+
+func TestParse_VariableLikeRuleIsNotRule(t *testing.T) {
+	t.Parallel()
+	makefile := `
+EXTENSION := .exe
+VAR ?= foo
+APPEND += bar
+SHELL != echo hi
+`
+	tmp := writeTempMakefile(t, makefile)
+	defer os.Remove(tmp)
+
+	ret, err := Parse(tmp)
+	require.NoError(t, err)
+
+	assert.Empty(t, ret.Rules, "variable assignments with ':=' or similar should not create rules")
+
+	varNames := []string{}
+	for _, v := range ret.Variables {
+		varNames = append(varNames, v.Name)
+	}
+	assert.Contains(t, varNames, "EXTENSION")
+	assert.Contains(t, varNames, "VAR")
+	assert.Contains(t, varNames, "APPEND")
+	assert.Contains(t, varNames, "SHELL")
 }

--- a/rules/minphony/minphony_test.go
+++ b/rules/minphony/minphony_test.go
@@ -70,6 +70,7 @@ var mpRunTests = []struct {
 }
 
 func TestMinPhony_new(t *testing.T) {
+	t.Parallel()
 	mp := &MinPhony{required: []string{"oh", "hai"}}
 
 	assert.Equal(t, []string{"oh", "hai"}, mp.required)
@@ -80,6 +81,7 @@ func TestMinPhony_new(t *testing.T) {
 }
 
 func TestMinPhony_Run(t *testing.T) {
+	t.Parallel()
 	mp := &MinPhony{required: []string{"kleen", "awl", "toast"}}
 
 	for _, test := range mpRunTests {
@@ -88,6 +90,7 @@ func TestMinPhony_Run(t *testing.T) {
 }
 
 func TestMinPhony_RunWithConfig(t *testing.T) {
+	t.Parallel()
 	mp := &MinPhony{required: []string{}}
 
 	mf := parser.Makefile{
@@ -126,6 +129,7 @@ func TestMinPhony_RunWithConfig(t *testing.T) {
 }
 
 func TestMinPhony_MissingPhonyDeclaration(t *testing.T) {
+	t.Parallel()
 	makefile := parser.Makefile{
 		FileName: "missing-phony.mk",
 		Rules: []parser.Rule{

--- a/rules/phonydeclared/phonydeclared_test.go
+++ b/rules/phonydeclared/phonydeclared_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAllTargetsArePhony(t *testing.T) {
+	t.Parallel()
 	makefile := parser.Makefile{
 		FileName: "phony-declared-all-phony.mk",
 		Variables: []parser.Variable{{
@@ -30,6 +31,7 @@ func TestAllTargetsArePhony(t *testing.T) {
 }
 
 func TestMissingOnePhonyTarget(t *testing.T) {
+	t.Parallel()
 	makefile := parser.Makefile{
 		FileName: "phony-declared-missing-one-phony.mk",
 		Variables: []parser.Variable{{

--- a/rules/uniquetargets/uniquetargets.go
+++ b/rules/uniquetargets/uniquetargets.go
@@ -55,6 +55,11 @@ func (r *UniqueTargets) Run(makefile parser.Makefile, cfg rules.RuleConfig) rule
 			continue
 		}
 
+		// Skip special built-ins like .PHONY
+		if rule.Target == ".PHONY" {
+			continue
+		}
+
 		if prevLine, exists := seen[rule.Target]; exists {
 			violations = append(violations, rules.RuleViolation{
 				Rule:       r.Name(),


### PR DESCRIPTION
This patch significantly improves the Makefile parser and related rules:

- Parser:
  - Support targets with special characters, patterns, and variables (`%.o`, `file.ext`, `$(DIR_VAR)`, `${DIR_VAR}/subdir`)
  - Add handling for inline recipes (`target: deps ; command`)
  - Recognize multiple-target rules (`target1 target2 : dep`)
  - Treat `.PHONY` and `.DEFAULT_GOAL` as rules (not variables)
  - Extend variable parsing to support `?=`, `!=`, and `+=` operators
  - Add detailed debug logging for ambiguous lines

- Rules:
  - Update `phonydeclared` and `minphony` to support both parser modes (old `.PHONY` as variable and new `.PHONY` as rule)
  - Remove legacy off-by-one adjustment on PHONY line numbers. Fixes inaccurate violation line reporting (+1 line shift)
  - Preserve fallback to -1 when PHONY is missing

- Tests:
  - Add new parser coverage for:
    - Inline recipes
    - Variable and pattern targets
    - Special characters, multiple targets, and file extensions
    - Other variable assignments (`?=`, `!=`, `+=`)
  - Adjust expected violation line numbers (from 21 to 22) for accurate reporting
  - Confirm full backward compatibility with existing fixtures

Overall, this modernizes the Makefile parser for complex rule syntax and brings line number reporting in sync with actual source positions.

## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [x] CI passes
- [x] Description of proposed change
- [ ] Documentation (README, docs/, man pages) is updated
- [ ] Existing issue is referenced if there is one
- [x] Unit tests for the proposed change
