### PR TITLE
feat(formatter): add JSON output support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ not do what you want it to.
 
 % checkmake Makefile foo.mk bar.mk baz.mk
 
-% checkmake --help
 checkmake scans Makefiles and reports potential issues according to configurable rules.
 
 Usage:
@@ -32,8 +31,9 @@ Available Commands:
 Flags:
       --config string   Configuration file to read (default "checkmake.ini")
       --debug           Enable debug mode
-      --format string   Output format as a Go text/template template
+      --format string   Custom Go template for text output (ignored in JSON mode)
   -h, --help            help for checkmake
+  -o, --output string   Output format: 'text' (default) or 'json' (mutually exclusive with --format) (default "text")
   -v, --version         version for checkmake
 
 Use "checkmake [command] --help" for more information about a command.

--- a/formatters/json.go
+++ b/formatters/json.go
@@ -1,0 +1,48 @@
+package formatters
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+
+	"github.com/checkmake/checkmake/rules"
+)
+
+// JSONFormatter is the formatter used for JSON output
+type JSONFormatter struct {
+	out io.Writer
+}
+
+// NewJSONFormatter returns a JSONFormatter struct
+func NewJSONFormatter() *JSONFormatter {
+	return &JSONFormatter{out: os.Stdout}
+}
+
+// Format is the function to call to get the formatted JSON output
+func (f *JSONFormatter) Format(violations rules.RuleViolationList) {
+	// Convert violations to JSON-serializable structure
+	type ViolationJSON struct {
+		Rule       string `json:"rule"`
+		Violation  string `json:"violation"`
+		FileName   string `json:"file_name"`
+		LineNumber int    `json:"line_number"`
+	}
+
+	violationsJSON := make([]ViolationJSON, len(violations))
+	for i, v := range violations {
+		violationsJSON[i] = ViolationJSON{
+			Rule:       v.Rule,
+			Violation:  v.Violation,
+			FileName:   v.FileName,
+			LineNumber: v.LineNumber,
+		}
+	}
+
+	encoder := json.NewEncoder(f.out)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(violationsJSON); err != nil {
+		// If encoding fails, we can't really recover, so we'll just return
+		// The error will be visible in the output stream
+		return
+	}
+}

--- a/formatters/json_test.go
+++ b/formatters/json_test.go
@@ -1,0 +1,71 @@
+package formatters
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/checkmake/checkmake/config"
+	"github.com/checkmake/checkmake/parser"
+	"github.com/checkmake/checkmake/rules"
+	"github.com/checkmake/checkmake/validator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSONFormatter(t *testing.T) {
+	out := new(bytes.Buffer)
+	formatter := JSONFormatter{out: out}
+
+	makefile, _ := parser.Parse("../fixtures/missing_phony.make")
+
+	violations := validator.Validate(makefile, &config.Config{})
+	formatter.Format(violations)
+
+	// Verify JSON output
+	var violationsJSON []struct {
+		Rule       string `json:"rule"`
+		Violation  string `json:"violation"`
+		FileName   string `json:"file_name"`
+		LineNumber int    `json:"line_number"`
+	}
+
+	err := json.Unmarshal(out.Bytes(), &violationsJSON)
+	require.NoError(t, err, "output should be valid JSON")
+
+	// Verify we have violations
+	assert.Greater(t, len(violationsJSON), 0, "should have at least one violation")
+
+	// Verify structure
+	for _, v := range violationsJSON {
+		assert.NotEmpty(t, v.Rule, "rule should not be empty")
+		assert.NotEmpty(t, v.Violation, "violation should not be empty")
+		assert.NotEmpty(t, v.FileName, "file_name should not be empty")
+		assert.Greater(t, v.LineNumber, 0, "line_number should be greater than 0")
+	}
+
+	// Verify specific violations are present
+	ruleNames := make(map[string]bool)
+	for _, v := range violationsJSON {
+		ruleNames[v.Rule] = true
+	}
+	assert.Contains(t, ruleNames, "phonydeclared", "should contain phonydeclared violation")
+}
+
+func TestJSONFormatter_EmptyViolations(t *testing.T) {
+	out := new(bytes.Buffer)
+	formatter := JSONFormatter{out: out}
+
+	var violations []struct {
+		Rule       string `json:"rule"`
+		Violation  string `json:"violation"`
+		FileName   string `json:"file_name"`
+		LineNumber int    `json:"line_number"`
+	}
+
+	formatter.Format(rules.RuleViolationList{})
+
+	err := json.Unmarshal(out.Bytes(), &violations)
+	require.NoError(t, err, "output should be valid JSON even with no violations")
+	assert.Equal(t, 0, len(violations), "should have empty array for no violations")
+}

--- a/man/man1/checkmake.1.md
+++ b/man/man1/checkmake.1.md
@@ -30,7 +30,30 @@ configurable rules being run against a Makefile or a set of `\*.mk` files.
 :    Specify the configuration file to read (default: `checkmake.ini`).
 
 **--format** *format*
-:    Set a custom output format using a Go `text/template` syntax.
+:    Set a custom output format using Go’s `text/template` syntax.
+     This option customizes how violations are displayed in **text mode**.
+     Cannot be used together with **--output** (mutually exclusive).
+
+     Example:
+
+     ```
+     checkmake --format '{{.Rule}}: {{.Violation}}' Makefile
+     ```
+
+**-o**, **--output** *mode*
+:    Select the overall output mode. Supported values:
+
+     - `text` (default): human-readable table or formatted text output.
+     - `json`: structured machine-readable JSON output.
+
+     When **--output=json** is specified, **--format** is ignored and violations
+     are printed as a JSON array.
+
+     Example:
+
+     ```
+     checkmake -o json Makefile | jq
+     ```
 
 # SUBCOMMANDS
 


### PR DESCRIPTION
Introduce a new `--output/-o` flag to select the output format (`text` or `json`). Implements a JSONFormatter for structured violation reporting and marks `--format` and `--output` as mutually exclusive for clarity.

## Checklist

- [x] Description of proposed change
- [x] Documentation (README, docs/, man pages) is updated
- [x] Unit tests for the proposed change
