### PR TITLE
github: Use latest stable Go release for workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: 1.25
+        go-version: 'stable'
       id: go
 
     - name: Check out code

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
 
-    - name: Set up Go 1.13
+    - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: 1.13
+        go-version: 'stable'
       id: go
 
     - name: Check out code
@@ -49,10 +49,10 @@ jobs:
 
     steps:
 
-    - name: Set up Go 1.17
+    - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: 1.17
+        go-version: 'stable'
       id: go
 
     - name: Check out code

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -29,9 +29,9 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - uses: actions/setup-python@v6
-    - name: Set up Go 1.17
+    - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: 1.17
+        go-version: 'stable'
       id: go
     - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
`setup-go` will get the latest stable version from the go-versions repository manifest.