### PR TITLE
Makefile: rework check,test,  and  lint targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       run: make clean all test
       shell: bash
 
-    - name: Run checkmake on Makefile
-      run: ./checkmake Makefile
+    - name: Selfcheck (Run checkmake on Makefile)
+      run: make check.self
       shell: bash
 

--- a/Makefile
+++ b/Makefile
@@ -106,8 +106,8 @@ require:
 test: lint
 	go test -v $(TEST_PKG)
 
-.PHONY: vet
-vet:
+.PHONY: go.vet
+go.vet:
 	@go vet ./...
 
 .PHONY: golangci-lint
@@ -118,7 +118,7 @@ $(GOLANGCI_LINT_BIN):
 	@go install github.com/golangci/golangci-lint/$(GOLANGCI_LINT_MAJOR_VER)/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
 .PHONY: lint
-lint: vet golangci-lint
+lint: go.vet golangci-lint
 
 
 .PHOHY: check.go.fmt

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,19 @@ $(GOLANGCI_LINT_BIN):
 lint: vet golangci-lint
 
 
+.PHOHY: check.go.fmt
+check.go.fmt:
+	@echo "Checking go formatting..."
+	@if [ -n "$$(gofmt -l .)" ]; then \
+			echo "Files need formatting:"; \
+				gofmt -l .; \
+				exit 1; \
+	else \
+		echo "All files formatted correctly."; \
+	fi
+
+.PHONY: check
+check: check.go.fmt lint
 
 
 coverage:

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,10 @@ check.go.fmt:
 .PHONY: check
 check: check.go.fmt lint
 
+.PHONY: fix.go.fmt
+fix.go.fmt: # fix go formatting (if needed)
+	@go fmt ./...
+
 
 coverage:
 	@echo "mode: set" > cover.out

--- a/Makefile
+++ b/Makefile
@@ -133,11 +133,15 @@ check.go.fmt:
 	fi
 
 .PHONY: check
-check: check.go.fmt lint
+check: check.go.fmt check.self lint
 
 .PHONY: fix.go.fmt
 fix.go.fmt: # fix go formatting (if needed)
 	@go fmt ./...
+
+.PHONY: check.self
+check.self: clean binaries # check this Makefile
+	@./checkmake ./Makefile
 
 
 coverage:

--- a/rules/minphony/minphony.go
+++ b/rules/minphony/minphony.go
@@ -20,7 +20,7 @@ func init() {
 	rules.RegisterRule(&MinPhony{required: defaultRequired})
 }
 
-//MinPhony is an empty struct on which to call the rule functions
+// MinPhony is an empty struct on which to call the rule functions
 type MinPhony struct {
 	required []string
 }


### PR DESCRIPTION
## Description

This reworks some test-related targets in te Makefile:

  * add a `check.sh.lint` target to lint shell scripts with shellcheck
  * add a `lint` target for running various format and syntax checks.
  * change the `check` target as to be a superset of `test`. 

## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [ ] CI passes
- [ ] Description of proposed change
- [ ] Documentation (README, docs/, man pages) is updated
- [ ] Existing issue is referenced if there is one
- [ ] Unit tests for the proposed change
