### PR TITLE
Rework makefile check lint test targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,21 +33,21 @@ jobs:
       if: matrix.os == 'windows-latest'
       run: |
         choco install -y make sed
-        choco install -y pandoc
+        choco install -y pandoc shellcheck
 
     - name: Install dependencies (macOS)
       if: matrix.os == 'macos-latest'
       run: |
-        brew install pandoc
+        brew install pandoc shellcheck
         
     - name: Install dependencies (Linux/Ubuntu)
       if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt update
-        sudo apt install -y pandoc
+        sudo apt install -y pandoc shellcheck
 
-    - name: Build and run unit tests
-      run: make clean all test
+    - name: lint, build and run unit tests
+      run: make check
       shell: bash
 
     - name: Selfcheck (Run checkmake on Makefile)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,3 @@ jobs:
       run: make check
       shell: bash
 
-    - name: Selfcheck (Run checkmake on Makefile)
-      run: make check.self
-      shell: bash
-

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ BUILD_GOPATH :=$(shell go env GOPATH)
 
 GOLANGCI_LINT_VERSION := latest
 GOLANGCI_LINT_MAJOR_VER := v2
-GOLANGCI_LINT_BIN:= $(BUILD_GOPATH)/bin/golangci-lint
+GOLANGCI_LINT_BIN := $(BUILD_GOPATH)/bin/golangci-lint
 
 
 
@@ -105,7 +105,7 @@ require:
 # development tasks
 
 .PHONY: test
-test: check
+test:
 	go test -v $(TEST_PKG)
 
 .PHONY: check.go.vet
@@ -117,6 +117,13 @@ check.go.vet:
 golangci-lint: $(GOLANGCI_LINT_BIN)
 	@echo "linting go code..."
 	@$(GOLANGCI_LINT_BIN) run
+
+
+.PHONY: check.sh.lint
+check.sh.lint: ## lint shell scripts ( requires shellcheck in the PATH.)
+	@echo "linting shell scripts..."
+	@shellcheck $(shell find . -name '*.sh')
+	@echo "All shell scripts are OK."
 
 
 $(GOLANGCI_LINT_BIN):
@@ -138,7 +145,11 @@ check.go.fmt:
 	fi
 
 .PHONY: check # perform various checks
-check: check.go.fmt check.go.lint check.self
+check: lint test check.self
+
+
+.PHONY: lint # perform linting (syntax and formatting) checks
+lint: check.go.fmt check.go.lint check.sh.lint
 
 .PHONY: fix.go.fmt
 fix.go.fmt: # fix go formatting (if needed)

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ BUILD_GOOS ?= $(shell go env GOOS)
 BUILD_GOARCH ?= $(shell go env GOARCH)
 BUILD_GOPATH :=$(shell go env GOPATH)
 
-GOLANGCI_LINT_VERSION := latest
+GOLANGCI_LINT_VERSION := v2.6.1 #latest
 GOLANGCI_LINT_MAJOR_VER := v2
 GOLANGCI_LINT_BIN := $(BUILD_GOPATH)/bin/golangci-lint
 


### PR DESCRIPTION
## Description

This reworks some test-related targets in the Makefile:

 * add a check.sh.lint target to lint shell scripts with shellcheck
 * add a lint target for running various format and syntax checks.
 * change the check target as to be a superset of test.



## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [ ] CI passes
- [ ] Description of proposed change
- [ ] Documentation (README, docs/, man pages) is updated
- [ ] Existing issue is referenced if there is one
- [ ] Unit tests for the proposed change
