### PR TITLE
fix: skip define/endef blocks during parsing

### DIFF
--- a/fixtures/define_block.make
+++ b/fixtures/define_block.make
@@ -1,0 +1,20 @@
+define MULTILINE_STRING
+
+some-test:
+1
+2
+3
+endef
+export MULTILINE_STRING
+
+.PHONY: test
+test:
+	@echo "$$MULTILINE_STRING"
+
+.PHONY: all
+all: test
+	@echo all
+
+.PHONY: clean
+clean:
+	@echo clean

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -76,6 +76,10 @@ var (
 	// Group 3: The value being assigned.
 	reFindOtherVariable = regexp.MustCompile(`^([A-Za-z0-9_.-]+)\s*([?!+]=)\s*(.*)`)
 
+	// reFindDefine matches the start of a multi-line variable definition block.
+	// Everything between "define" and "endef" should be skipped by the parser.
+	reFindDefine = regexp.MustCompile(`^\s*define\s+`)
+
 	// reFindSpecialTarget captures special Make targets that start with a dot, like .PHONY.
 	// Group 1: The special target name (e.g., ".PHONY").
 	// Group 2: The prerequisites/dependencies (e.g., "all clean test").
@@ -99,6 +103,18 @@ func Parse(filepath string) (ret Makefile, err error) {
 		case strings.HasPrefix(scanner.Text(), "#"):
 			// parse comments here, ignoring them for now
 			scanner.Scan()
+		case reFindDefine.MatchString(scanner.Text()):
+			// Skip multi-line variable blocks (define ... endef).
+			// Lines inside these blocks are not rules or variables.
+			// If endef is missing, the parser skips to EOF.
+			scanner.Scan()
+			for !scanner.Finished && strings.TrimSpace(scanner.Text()) != "endef" {
+				scanner.Scan()
+			}
+			// Skip the "endef" line itself
+			if !scanner.Finished {
+				scanner.Scan()
+			}
 		case strings.HasPrefix(scanner.Text(), "."):
 			if matches := reFindSpecialTarget.FindStringSubmatch(scanner.Text()); matches != nil {
 				// Treat special targets like .PHONY or .DEFAULT_GOAL as rules, not variables

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -309,6 +309,78 @@ APPEND_VAR += more stuff
 	assert.False(t, appendVar.SimplyExpanded, "+= should default to recursive (false)")
 }
 
+func TestParse_DefineBlockSkipped(t *testing.T) {
+	t.Parallel()
+	ret, err := Parse("../fixtures/define_block.make")
+
+	require.NoError(t, err)
+
+	// The define block should be skipped entirely; "some-test:" inside it
+	// must NOT be parsed as a rule.
+	targets := make([]string, len(ret.Rules))
+	for i, r := range ret.Rules {
+		targets[i] = r.Target
+	}
+
+	assert.NotContains(t, targets, "some-test",
+		"lines inside define/endef blocks should not be parsed as rules")
+
+	// The real targets should still be parsed correctly.
+	assert.Contains(t, targets, ".PHONY")
+	assert.Contains(t, targets, "test")
+	assert.Contains(t, targets, "all")
+	assert.Contains(t, targets, "clean")
+}
+
+func TestParse_MultipleDefineBlocks(t *testing.T) {
+	t.Parallel()
+	makefile := `
+define BLOCK_A
+fake-target-a:
+endef
+
+define BLOCK_B
+fake-target-b:
+endef
+
+.PHONY: all
+all:
+	@echo done
+`
+	tmp := writeTempMakefile(t, makefile)
+	defer os.Remove(tmp)
+
+	ret, err := Parse(tmp)
+	require.NoError(t, err)
+
+	targets := make([]string, len(ret.Rules))
+	for i, r := range ret.Rules {
+		targets[i] = r.Target
+	}
+
+	assert.NotContains(t, targets, "fake-target-a",
+		"lines inside first define block should not be parsed as rules")
+	assert.NotContains(t, targets, "fake-target-b",
+		"lines inside second define block should not be parsed as rules")
+	assert.Contains(t, targets, "all")
+}
+
+func TestParse_UnclosedDefineBlock(t *testing.T) {
+	t.Parallel()
+	makefile := `
+define UNCLOSED
+fake-target:
+`
+	tmp := writeTempMakefile(t, makefile)
+	defer os.Remove(tmp)
+
+	// Should not hang or panic; the parser skips to EOF.
+	ret, err := Parse(tmp)
+	require.NoError(t, err)
+
+	assert.Empty(t, ret.Rules, "unclosed define block should not produce rules")
+}
+
 func TestParse_VariableLikeRuleIsNotRule(t *testing.T) {
 	t.Parallel()
 	makefile := `


### PR DESCRIPTION
Fixes #244

## Problem

The parser does not recognize multi-line variable definitions (`define ... endef`). Lines inside these blocks are incorrectly parsed as rules or variables, causing false violations.

For example, this Makefile:

```makefile
define MULTILINE_STRING
some-test:
endef
```

produces a false `phonydeclared` violation for `some-test`, even though it is inside a multi-line variable, not a real target.

## Fix

Skip all lines between `define` and `endef` during parsing. The implementation:

- Adds a regex to detect `define` lines (with optional leading whitespace)
- Skips forward until `endef` is found (or EOF, for unclosed blocks)
- Does not affect any other parsing paths

## Validation

- Reproduced the bug from the issue with the exact Makefiles provided
- All existing tests pass (`go test ./...`)
- Added tests for: basic define block, multiple sequential blocks, unclosed define block