### PR TITLE
fix: consume space-indented backslash continuation lines in recipe body

### DIFF
--- a/fixtures/backslash_continuation.make
+++ b/fixtures/backslash_continuation.make
@@ -1,0 +1,14 @@
+# Fixture for issue #244 – backslash line-continuation in recipe bodies.
+#
+# When a recipe line ends with '\' and the continuation lines use space
+# indentation (rather than a leading tab), the parser fails to recognise them
+# as body lines.  Any such continuation line that also contains ':' is
+# incorrectly parsed as a new rule target, triggering a spurious
+# phonydeclared violation.
+
+.PHONY: celerybeat
+
+celerybeat: reset_redis
+	pipenv run celery -A myproject beat \
+        --scheduler django_celery_beat.schedulers:DatabaseScheduler \
+        --loglevel=INFO

--- a/fixtures/backslash_continuation.make
+++ b/fixtures/backslash_continuation.make
@@ -1,4 +1,4 @@
-# Fixture for issue #244 – backslash line-continuation in recipe bodies.
+# Fixture for issue #257 - backslash line-continuation in recipe bodies.
 #
 # When a recipe line ends with '\' and the continuation lines use space
 # indentation (rather than a leading tab), the parser fails to recognise them

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -228,8 +228,17 @@ func parseRuleOrVariable(scanner *MakefileScanner) (ret interface{}, err error) 
 
 		// collect tab-indented body lines after the rule
 		for bodyMatches := reFindRuleBody.FindStringSubmatch(scanner.Text()); bodyMatches != nil; bodyMatches = reFindRuleBody.FindStringSubmatch(scanner.Text()) {
-			ruleBody = append(ruleBody, strings.TrimSpace(bodyMatches[1]))
+			line := strings.TrimSpace(bodyMatches[1])
+			ruleBody = append(ruleBody, line)
 			scanner.Scan()
+			// If the line ended with a backslash, consume continuation lines
+			// regardless of their indentation. Space-indented continuations
+			// are common when aligning flags under a long command.
+			for strings.HasSuffix(line, `\`) {
+				line = strings.TrimSpace(scanner.Text())
+				ruleBody = append(ruleBody, line)
+				scanner.Scan()
+			}
 		}
 
 		ret = Rule{

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -310,8 +310,8 @@ APPEND_VAR += more stuff
 }
 
 // ---------------------------------------------------------------------------
-// Issue #244 – backslash line-continuation in recipe bodies
-// (reported at https://github.com/checkmake/checkmake/issues/244#issuecomment-4344766044)
+// Issue #257 - backslash line-continuation in recipe bodies
+// (reported at https://github.com/checkmake/checkmake/issues/257)
 // ---------------------------------------------------------------------------
 //
 // Root cause: when a recipe command is written across multiple lines using a
@@ -329,7 +329,7 @@ APPEND_VAR += more stuff
 //   Target "--scheduler django_celery_beat.schedulers" should be declared PHONY.
 
 // TestParse_BackslashContinuation_SpaceIndented is the primary regression test
-// for issue #244.  It uses the exact pattern from the bug report: the first
+// for issue #257.  It uses the exact pattern from the bug report: the first
 // recipe line starts with a TAB and ends with '\'; the continuation lines use
 // SPACE indentation (as is common when aligning flags under a command).
 //

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -309,6 +309,164 @@ APPEND_VAR += more stuff
 	assert.False(t, appendVar.SimplyExpanded, "+= should default to recursive (false)")
 }
 
+// ---------------------------------------------------------------------------
+// Issue #244 – backslash line-continuation in recipe bodies
+// (reported at https://github.com/checkmake/checkmake/issues/244#issuecomment-4344766044)
+// ---------------------------------------------------------------------------
+//
+// Root cause: when a recipe command is written across multiple lines using a
+// trailing '\', the continuation lines are commonly indented with SPACES (not
+// a tab) for visual alignment.  The body-collection loop in the parser uses
+// the regex `^\t+(.*)` which requires a leading tab, so space-indented
+// continuation lines are silently dropped from the rule body.
+//
+// When such a continuation line also contains a colon (e.g. a --scheduler
+// flag whose value contains a Python module path like
+// "django_celery_beat.schedulers:DatabaseScheduler"), the parser's
+// reFindRule regex matches it and registers it as a brand-new rule target.
+// The phonydeclared rule then fires a spurious violation:
+//
+//   Target "--scheduler django_celery_beat.schedulers" should be declared PHONY.
+
+// TestParse_BackslashContinuation_SpaceIndented is the primary regression test
+// for issue #244.  It uses the exact pattern from the bug report: the first
+// recipe line starts with a TAB and ends with '\'; the continuation lines use
+// SPACE indentation (as is common when aligning flags under a command).
+//
+// Expected (correct) behaviour after the fix:
+//   – ret.Rules contains exactly ONE rule ("celerybeat")
+//   – the continuation fragments are NOT parsed as extra rules
+//
+// Current (buggy) behaviour that this test exposes:
+//   – "--scheduler django_celery_beat.schedulers" is parsed as a second rule
+//     because the space-indented line `        --scheduler ...:Database...`
+//     is not consumed as a body line and its colon tricks reFindRule.
+func TestParse_BackslashContinuation_SpaceIndented(t *testing.T) {
+	t.Parallel()
+
+	// Reproduce the exact snippet from the bug comment.
+	// Note: the first recipe line starts with \t; continuations use spaces.
+	makefile := ".PHONY: celerybeat\n" +
+		"celerybeat: reset_redis\n" +
+		"\tpipenv run celery -A myproject beat \\\n" +
+		"        --scheduler django_celery_beat.schedulers:DatabaseScheduler \\\n" +
+		"        --loglevel=INFO\n"
+
+	tmp := writeTempMakefile(t, makefile)
+	defer os.Remove(tmp)
+
+	ret, err := Parse(tmp)
+	require.NoError(t, err)
+
+	// Collect all parsed rule targets for a readable failure message.
+	targets := make([]string, len(ret.Rules))
+	for i, r := range ret.Rules {
+		targets[i] = r.Target
+	}
+
+	// BUG: the parser currently creates a spurious rule whose target is
+	// "--scheduler django_celery_beat.schedulers".  After the fix there should
+	// be exactly two rules: ".PHONY" and "celerybeat".
+	assert.NotContains(t, targets, "--scheduler django_celery_beat.schedulers",
+		"space-indented continuation line must not be parsed as a rule target")
+
+	assert.Len(t, ret.Rules, 2,
+		"only '.PHONY' and 'celerybeat' should be parsed as rules; got: %v", targets)
+}
+
+// TestParse_BackslashContinuation_BodyNotTruncated checks the companion
+// symptom: the celerybeat rule's body must contain all three recipe lines
+// (the initial command plus its two continuation lines), not just the first.
+//
+// BUG: currently the body stops at the first line because the space-indented
+// continuations are not recognised as body lines.
+func TestParse_BackslashContinuation_BodyNotTruncated(t *testing.T) {
+	t.Parallel()
+
+	makefile := ".PHONY: celerybeat\n" +
+		"celerybeat: reset_redis\n" +
+		"\tpipenv run celery -A myproject beat \\\n" +
+		"        --scheduler django_celery_beat.schedulers:DatabaseScheduler \\\n" +
+		"        --loglevel=INFO\n"
+
+	tmp := writeTempMakefile(t, makefile)
+	defer os.Remove(tmp)
+
+	ret, err := Parse(tmp)
+	require.NoError(t, err)
+
+	// Find the celerybeat rule.
+	var celeryRule *Rule
+	for i := range ret.Rules {
+		if ret.Rules[i].Target == "celerybeat" {
+			celeryRule = &ret.Rules[i]
+			break
+		}
+	}
+	require.NotNil(t, celeryRule, "celerybeat rule must be present")
+
+	// The body should contain all three physical recipe lines.
+	// BUG: currently only the first (tab-indented) line is captured.
+	assert.Len(t, celeryRule.Body, 3,
+		"all three recipe lines (initial + 2 space-indented continuations) must be in the body")
+}
+
+// TestParse_BackslashContinuation_TabIndentedBaseline confirms that the
+// existing behaviour for fully tab-indented continuations is unaffected.
+// This test is expected to PASS both before and after the fix.
+func TestParse_BackslashContinuation_TabIndentedBaseline(t *testing.T) {
+	t.Parallel()
+
+	// All continuation lines start with a tab – the parser already handles this.
+	makefile := ".PHONY: build\n" +
+		"build:\n" +
+		"\techo alpha\n" +
+		"\techo beta\n" +
+		"\techo gamma\n"
+
+	tmp := writeTempMakefile(t, makefile)
+	defer os.Remove(tmp)
+
+	ret, err := Parse(tmp)
+	require.NoError(t, err)
+
+	var buildRule *Rule
+	for i := range ret.Rules {
+		if ret.Rules[i].Target == "build" {
+			buildRule = &ret.Rules[i]
+			break
+		}
+	}
+	require.NotNil(t, buildRule, "build rule must be present")
+	assert.Len(t, buildRule.Body, 3,
+		"three independent tab-indented lines should produce Body length 3")
+}
+
+// TestParse_BackslashContinuation_FixtureFile exercises the exact fixture file
+// that mirrors the bug-report snippet (fixtures/backslash_continuation.make).
+func TestParse_BackslashContinuation_FixtureFile(t *testing.T) {
+	t.Parallel()
+
+	ret, err := Parse("../fixtures/backslash_continuation.make")
+	require.NoError(t, err)
+
+	targets := make([]string, len(ret.Rules))
+	for i, r := range ret.Rules {
+		targets[i] = r.Target
+	}
+
+	// BUG: the space-indented continuation line
+	//   "        --scheduler django_celery_beat.schedulers:DatabaseScheduler \\"
+	// is being misidentified as a rule target.
+	assert.NotContains(t, targets,
+		"--scheduler django_celery_beat.schedulers",
+		"continuation line fragment must not appear as a rule target")
+
+	// After the fix only .PHONY and celerybeat should be present.
+	assert.Len(t, ret.Rules, 2,
+		"only '.PHONY' and 'celerybeat' should be parsed; got: %v", targets)
+}
+
 func TestParse_VariableLikeRuleIsNotRule(t *testing.T) {
 	t.Parallel()
 	makefile := `

--- a/rules/maxbodylength/maxbodylength_test.go
+++ b/rules/maxbodylength/maxbodylength_test.go
@@ -69,7 +69,7 @@ func TestFooIsTooLongWithConfig(t *testing.T) {
 }
 
 // TestMaxBodyLength_BackslashContinuation documents the secondary maxbodylength
-// symptom of issue #244.
+// symptom of issue #257.
 //
 // Once the parser is fixed and correctly collects all three recipe lines
 // (the tab-indented start line + two space-indented continuation lines) into
@@ -85,7 +85,7 @@ func TestMaxBodyLength_BackslashContinuation(t *testing.T) {
 			Target: "celerybeat",
 			// Three body lines: the initial tab-indented command plus the two
 			// space-indented continuation lines — as the parser should return
-			// after the issue #244 fix.
+			// after the issue #257 fix.
 			Body: []string{
 				`pipenv run celery -A myproject beat \`,
 				`--scheduler django_celery_beat.schedulers:DatabaseScheduler \`,

--- a/rules/maxbodylength/maxbodylength_test.go
+++ b/rules/maxbodylength/maxbodylength_test.go
@@ -67,3 +67,37 @@ func TestFooIsTooLongWithConfig(t *testing.T) {
 	assert.Equal(t, 1, ret[0].LineNumber)
 	assert.Equal(t, "maxbodylength.mk", ret[0].FileName)
 }
+
+// TestMaxBodyLength_BackslashContinuation documents the secondary maxbodylength
+// symptom of issue #244.
+//
+// Once the parser is fixed and correctly collects all three recipe lines
+// (the tab-indented start line + two space-indented continuation lines) into
+// the celerybeat body, maxbodylength must NOT fire — three lines is well within
+// the default limit of 5.
+//
+// This test operates directly on a pre-built Makefile struct so that the
+// rule logic can be verified independently of the parser fix.
+func TestMaxBodyLength_BackslashContinuation(t *testing.T) {
+	makefile := parser.Makefile{
+		FileName: "backslash.mk",
+		Rules: []parser.Rule{{
+			Target: "celerybeat",
+			// Three body lines: the initial tab-indented command plus the two
+			// space-indented continuation lines — as the parser should return
+			// after the issue #244 fix.
+			Body: []string{
+				`pipenv run celery -A myproject beat \`,
+				`--scheduler django_celery_beat.schedulers:DatabaseScheduler \`,
+				`--loglevel=INFO`,
+			},
+			LineNumber: 1,
+		}},
+	}
+
+	rule := MaxBodyLength{}
+	ret := rule.Run(makefile, rules.RuleConfig{})
+
+	assert.Empty(t, ret,
+		"three body lines is within the default limit of 5; no maxbodylength violation expected")
+}

--- a/rules/phonydeclared/phonydeclared_test.go
+++ b/rules/phonydeclared/phonydeclared_test.go
@@ -31,7 +31,7 @@ func TestAllTargetsArePhony(t *testing.T) {
 }
 
 // TestPhonyDeclared_BackslashContinuation is the rule-level regression test
-// for issue #244 (comment https://github.com/checkmake/checkmake/issues/244#issuecomment-4344766044).
+// for issue #257 (https://github.com/checkmake/checkmake/issues/257).
 //
 // The parser currently misidentifies the space-indented continuation line
 //
@@ -85,10 +85,10 @@ func TestPhonyDeclared_BackslashContinuation(t *testing.T) {
 
 	// After the fix the parser will not produce the spurious rule, so
 	// phonydeclared will have nothing to complain about.
-	// FAILING until issue #244 is fixed in the parser.
+	// FAILING until issue #257 is fixed in the parser.
 	for _, v := range ret {
 		if v.Violation == `Target "--scheduler django_celery_beat.schedulers" should be declared PHONY.` {
-			t.Errorf("BUG #244: spurious phonydeclared violation for continuation line fragment: %s", v.Violation)
+			t.Errorf("BUG #257: spurious phonydeclared violation for continuation line fragment: %s", v.Violation)
 		}
 	}
 

--- a/rules/phonydeclared/phonydeclared_test.go
+++ b/rules/phonydeclared/phonydeclared_test.go
@@ -30,6 +30,72 @@ func TestAllTargetsArePhony(t *testing.T) {
 	assert.Equal(t, len(ret), 0)
 }
 
+// TestPhonyDeclared_BackslashContinuation is the rule-level regression test
+// for issue #244 (comment https://github.com/checkmake/checkmake/issues/244#issuecomment-4344766044).
+//
+// The parser currently misidentifies the space-indented continuation line
+//
+//   "        --scheduler django_celery_beat.schedulers:DatabaseScheduler \\"
+//
+// as a rule target because it is not consumed by the tab-only body-collection
+// loop and its colon matches reFindRule.  phonydeclared then fires:
+//
+//   Target "--scheduler django_celery_beat.schedulers" should be declared PHONY.
+//
+// This test builds the Makefile struct that the parser *currently* produces
+// (the buggy state) and asserts that phonydeclared must NOT raise a violation
+// for the spurious target.  The test will FAIL until the parser is fixed.
+func TestPhonyDeclared_BackslashContinuation(t *testing.T) {
+	t.Parallel()
+
+	// This is the struct the parser currently produces for:
+	//
+	//   .PHONY: celerybeat
+	//   celerybeat: reset_redis
+	//   \tpipenv run celery -A myproject beat \
+	//           --scheduler django_celery_beat.schedulers:DatabaseScheduler \
+	//           --loglevel=INFO
+	//
+	// BUG: the spurious rule whose target is
+	// "--scheduler django_celery_beat.schedulers" should not exist.
+	makefile := parser.Makefile{
+		FileName: "celery.mk",
+		Rules: []parser.Rule{
+			{
+				Target:       ".PHONY",
+				Dependencies: []string{"celerybeat"},
+			},
+			{
+				Target:       "celerybeat",
+				Dependencies: []string{"reset_redis"},
+				// BUG: currently only the first tab-indented line ends up here.
+				Body: []string{`pipenv run celery -A myproject beat \`},
+			},
+			// BUG: these two rules should not exist – they are continuation
+			// lines that were misidentified as targets by the parser.
+			{
+				Target: "--scheduler django_celery_beat.schedulers",
+				Body:   []string{},
+			},
+		},
+	}
+
+	rule := Phonydeclared{}
+	ret := rule.Run(makefile, rules.RuleConfig{})
+
+	// After the fix the parser will not produce the spurious rule, so
+	// phonydeclared will have nothing to complain about.
+	// FAILING until issue #244 is fixed in the parser.
+	for _, v := range ret {
+		if v.Violation == `Target "--scheduler django_celery_beat.schedulers" should be declared PHONY.` {
+			t.Errorf("BUG #244: spurious phonydeclared violation for continuation line fragment: %s", v.Violation)
+		}
+	}
+
+	assert.Empty(t, ret,
+		"no phonydeclared violations expected: the continuation line is not a real target")
+}
+
 func TestMissingOnePhonyTarget(t *testing.T) {
 	t.Parallel()
 	makefile := parser.Makefile{

--- a/rules/phonydeclared/phonydeclared_test.go
+++ b/rules/phonydeclared/phonydeclared_test.go
@@ -1,11 +1,13 @@
 package phonydeclared
 
 import (
+	"os"
 	"testing"
 
 	"github.com/checkmake/checkmake/parser"
 	"github.com/checkmake/checkmake/rules"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAllTargetsArePhony(t *testing.T) {
@@ -30,70 +32,36 @@ func TestAllTargetsArePhony(t *testing.T) {
 	assert.Equal(t, len(ret), 0)
 }
 
-// TestPhonyDeclared_BackslashContinuation is the rule-level regression test
+// TestPhonyDeclared_BackslashContinuation is the end-to-end regression test
 // for issue #257 (https://github.com/checkmake/checkmake/issues/257).
 //
-// The parser currently misidentifies the space-indented continuation line
-//
-//   "        --scheduler django_celery_beat.schedulers:DatabaseScheduler \\"
-//
-// as a rule target because it is not consumed by the tab-only body-collection
-// loop and its colon matches reFindRule.  phonydeclared then fires:
-//
-//   Target "--scheduler django_celery_beat.schedulers" should be declared PHONY.
-//
-// This test builds the Makefile struct that the parser *currently* produces
-// (the buggy state) and asserts that phonydeclared must NOT raise a violation
-// for the spurious target.  The test will FAIL until the parser is fixed.
+// Space-indented backslash continuation lines in a recipe body must not be
+// misidentified as rule targets by the parser, and phonydeclared must not
+// fire a spurious violation for them.
 func TestPhonyDeclared_BackslashContinuation(t *testing.T) {
 	t.Parallel()
 
-	// This is the struct the parser currently produces for:
-	//
-	//   .PHONY: celerybeat
-	//   celerybeat: reset_redis
-	//   \tpipenv run celery -A myproject beat \
-	//           --scheduler django_celery_beat.schedulers:DatabaseScheduler \
-	//           --loglevel=INFO
-	//
-	// BUG: the spurious rule whose target is
-	// "--scheduler django_celery_beat.schedulers" should not exist.
-	makefile := parser.Makefile{
-		FileName: "celery.mk",
-		Rules: []parser.Rule{
-			{
-				Target:       ".PHONY",
-				Dependencies: []string{"celerybeat"},
-			},
-			{
-				Target:       "celerybeat",
-				Dependencies: []string{"reset_redis"},
-				// BUG: currently only the first tab-indented line ends up here.
-				Body: []string{`pipenv run celery -A myproject beat \`},
-			},
-			// BUG: these two rules should not exist – they are continuation
-			// lines that were misidentified as targets by the parser.
-			{
-				Target: "--scheduler django_celery_beat.schedulers",
-				Body:   []string{},
-			},
-		},
-	}
+	content := ".PHONY: celerybeat\n" +
+		"celerybeat: reset_redis\n" +
+		"\tpipenv run celery -A myproject beat \\\n" +
+		"        --scheduler django_celery_beat.schedulers:DatabaseScheduler \\\n" +
+		"        --loglevel=INFO\n"
+
+	f, err := os.CreateTemp("", "*.mk")
+	require.NoError(t, err)
+	_, err = f.WriteString(content)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	defer os.Remove(f.Name())
+
+	makefile, err := parser.Parse(f.Name())
+	require.NoError(t, err)
 
 	rule := Phonydeclared{}
 	ret := rule.Run(makefile, rules.RuleConfig{})
 
-	// After the fix the parser will not produce the spurious rule, so
-	// phonydeclared will have nothing to complain about.
-	// FAILING until issue #257 is fixed in the parser.
-	for _, v := range ret {
-		if v.Violation == `Target "--scheduler django_celery_beat.schedulers" should be declared PHONY.` {
-			t.Errorf("BUG #257: spurious phonydeclared violation for continuation line fragment: %s", v.Violation)
-		}
-	}
-
 	assert.Empty(t, ret,
-		"no phonydeclared violations expected: the continuation line is not a real target")
+		"no phonydeclared violations expected: continuation lines are not rule targets")
 }
 
 func TestMissingOnePhonyTarget(t *testing.T) {


### PR DESCRIPTION
Fixes #257

## Description of proposed change

When a recipe line ends with a trailing backslash and the continuation
lines use space indentation (rather than a tab), the parser did not
recognise those lines as part of the recipe body. They were passed back
to the top-level parser, and any continuation line containing a colon
was misidentified as a rule target. phonydeclared then fired a spurious
violation, for example:

    Target "--scheduler django_celery_beat.schedulers" should be declared PHONY.

The fix is in the body-collection loop in parseRuleOrVariable
(parser/parser.go). After collecting a tab-indented body line that ends
with a backslash, the loop now continues consuming subsequent lines
regardless of their leading whitespace, matching standard Make behaviour
for line continuations.

## Unit tests for the proposed change

    parser/parser_test.go
      TestParse_BackslashContinuation_SpaceIndented
      TestParse_BackslashContinuation_BodyNotTruncated
      TestParse_BackslashContinuation_TabIndentedBaseline
      TestParse_BackslashContinuation_FixtureFile

    rules/phonydeclared/phonydeclared_test.go
      TestPhonyDeclared_BackslashContinuation

    rules/maxbodylength/maxbodylength_test.go
      TestMaxBodyLength_BackslashContinuation

## Checklist

- [ ] CI passes
- [x] Description of proposed change
- [x] Documentation (README, docs/, man pages) is updated -- no doc changes needed, this is an internal parser bug fix with no user-facing changes
- [x] Existing issue is referenced if there is one
- [x] Unit tests for the proposed change