### PR TITLE
Makefile add workflow linting

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -80,12 +80,12 @@ jobs:
     steps:
     - uses: actions/checkout@v7
     - name: Build the Docker image
-      run: docker build --build-arg BUILDER_NAME=CI --build-arg BUILDER_EMAIL=ci@test.only . --file Dockerfile --tag mrtazz/checkmake:${GITHUB_SHA} --tag mrtazz/checkmake:latest
+      run: docker build --build-arg BUILDER_NAME=CI --build-arg BUILDER_EMAIL=ci@test.only . --file Dockerfile --tag mrtazz/checkmake:"${GITHUB_SHA}" --tag mrtazz/checkmake:latest
 
     - name: push the docker image to docker hub
       if: github.ref == 'refs/heads/main'
       run: |
-        echo ${{ secrets.DOCKER_HUB_TOKEN }} | docker login -u mrtazz --password-stdin
-        docker push mrtazz/checkmake:${GITHUB_SHA}
+        echo "${{ secrets.DOCKER_HUB_TOKEN }}" | docker login -u mrtazz --password-stdin
+        docker push mrtazz/checkmake:"${GITHUB_SHA}"
         docker push mrtazz/checkmake:latest
         docker logout hub.docker.com

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ GOLANGCI_LINT_VERSION := v2.13.0 # pinned
 GOLANGCI_LINT_MAJOR_VER := v2
 GOLANGCI_LINT_BIN := $(BUILD_GOPATH)/bin/golangci-lint
 
+ACTIONLINT_VERSION := v1.7.12 # pinned
+ACTIONLINT_BIN := $(BUILD_GOPATH)/bin/actionlint
+
 
 
 IMAGE_REGISTRY ?= quay.io
@@ -126,6 +129,15 @@ lint.shell: ## lint shell scripts ( requires shellcheck in the PATH.)
 	@echo "All shell scripts are OK."
 
 
+.PHONY: lint.workflows
+lint.workflows: $(ACTIONLINT_BIN) ## lint github workflow files
+	@echo "linting GitHub workflows..."
+	@$(ACTIONLINT_BIN) --color
+	@echo "all workflows are good"
+
+$(ACTIONLINT_BIN):
+	@go install github.com/rhysd/actionlint/cmd/actionlint@$(ACTIONLINT_VERSION)
+
 $(GOLANGCI_LINT_BIN):
 	@go install github.com/golangci/golangci-lint/$(GOLANGCI_LINT_MAJOR_VER)/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
 
@@ -149,7 +161,7 @@ check: lint test check.self
 
 
 .PHONY: lint # perform linting (syntax and formatting) checks
-lint: check.go.fmt lint.go lint.shell
+lint: check.go.fmt lint.go lint.shell lint.workflows
 
 .PHONY: fix.go.fmt
 fix.go.fmt: # fix go formatting (if needed)
@@ -265,6 +277,5 @@ image-build:
 .PHONY: image-push
 image-push:
 	$(CONTAINER_CMD) push $(IMG)
-
 
 


### PR DESCRIPTION
## Description

    This adds linting of GitHub workflow files with actionlint.
workflow linting can be invoked with make lint.workflows.
    
The target is self-contained in that it does not require the actionlint
tool to be installed on the host.
    
workflow linting is also added to lint and thereby check and the CI.



## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [ ] CI passes
- [ ] Description of proposed change
- [ ] Documentation (README, docs/, man pages) is updated
- [ ] Existing issue is referenced if there is one
- [ ] Unit tests for the proposed change
