### PR TITLE
Makefile: make the check.self target more verbose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,10 @@ fix.go.fmt: # fix go formatting (if needed)
 
 .PHONY: check.self
 check.self: clean binaries # check this Makefile
+	@echo "checking our own Makefile..."
 	@./checkmake ./Makefile
+	@echo "Makefile is good."
+
 
 
 coverage:


### PR DESCRIPTION
## Description 

This adds some helpful output to `make check.self`
similar to various linting targets.

## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [ ] CI passes
- [ ] Description of proposed change
- [ ] Documentation (README, docs/, man pages) is updated
- [ ] Existing issue is referenced if there is one
- [ ] Unit tests for the proposed change
