### PR TITLE
CI : run CI jobs on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,14 @@
 name: CI
 on:
+  push:
+    branches:
+      - main
+      - release-*
   workflow_dispatch:
   pull_request:
+    branches:
+      - main
+      - release-*
     types: [opened, synchronize]
 
 jobs:


### PR DESCRIPTION
## Description
This lets the CI checks run on push/merge to main and release branches.

This is done so that hte CI status badge in the README can show a status.

## Checklist
Not all of these might apply to your change but the more you are able to check
the easier it will be to get your contribution merged.

- [ ] CI passes
- [x] Description of proposed change
- [x] Documentation (README, docs/, man pages) is updated
- [x] Existing issue is referenced if there is one
- [x] Unit tests for the proposed change
